### PR TITLE
Stash the built plugin in GitHub for 3 days

### DIFF
--- a/.github/workflows/openfire-plugin-build.yml
+++ b/.github/workflows/openfire-plugin-build.yml
@@ -118,6 +118,14 @@ jobs:
           set -e
           mvn -B package
 
+      - name: Stash the built artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.java == 11}}
+        with:
+          name: ${{ steps.get-id.outputs.id }}
+          path: target/${{ steps.get-id.outputs.id }}-openfire-plugin-assembly.jar
+          retention-days: 3
+
       - name: Conditionally Deploy to Igniterealtime Archiva
         id: deploy
         if: ${{ contains(github.repository, 'igniterealtime/') && ( ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || contains(github.ref, 'refs/tags/')) && ( matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') ) }}


### PR DESCRIPTION
To use the plugin later in a workflow, or to debug a build, we might want to hold onto the plugin for a short while.
This adds a step to store a couple of MB in GitHub for 3 days.

Successful run in the Example Plugin: https://github.com/igniterealtime/openfire-exampleplugin/actions/runs/11196521235