### PR TITLE
Add support for Java 17

### DIFF
--- a/.github/workflows/openfire-plugin-build.yml
+++ b/.github/workflows/openfire-plugin-build.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Stash the built artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') || (matrix.java == '17' && needs.select_java.outputs.java == '[17,21]') }}
+        if: ${{ fromJson(needs.select_java.outputs.java)[0] == matrix.java }}
         with:
           name: ${{ steps.get-id.outputs.id }}
           path: target/${{ steps.get-id.outputs.id }}-openfire-plugin-assembly.jar
@@ -130,7 +130,7 @@ jobs:
 
       - name: Conditionally Deploy to Igniterealtime Archiva
         id: deploy
-        if: ${{ contains(github.repository, 'igniterealtime/') && ( ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || contains(github.ref, 'refs/tags/')) && ( matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') || (matrix.java == '17' && needs.select_java.outputs.java == '[17,21]') ) }}
+        if: ${{ contains(github.repository, 'igniterealtime/') && ( ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || contains(github.ref, 'refs/tags/')) && fromJson(needs.select_java.outputs.java)[0] == matrix.java }}
         run: |
           set -e
           mvn -B deploy -Dmaven.resolver.transport=wagon --settings target/ci-tooling/maven-settings-for-openfire-plugins.xml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Conditionally Push Artifact to Github Release
         uses: actions/upload-release-asset@v1
-        if: ${{ contains(github.repository, 'igniterealtime/') && github.event_name == 'push' && contains(github.ref, 'refs/tags/') && ( matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') || (matrix.java == '17' && needs.select_java.outputs.java == '[17,21]') ) }}
+        if: ${{ contains(github.repository, 'igniterealtime/') && github.event_name == 'push' && contains(github.ref, 'refs/tags/') && fromJson(needs.select_java.outputs.java)[0] == matrix.java }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/openfire-plugin-build.yml
+++ b/.github/workflows/openfire-plugin-build.yml
@@ -1,6 +1,6 @@
 # Version 2023-03-05
 name: Java CI
-on: 
+on:
   workflow_call:
     secrets:
       IGNITE_REALTIME_MAVEN_USERNAME:
@@ -51,7 +51,9 @@ jobs:
         id: set-java-targets
         run: |
           set -e
-          if [ "${{steps.get-java-version-from-plugin-xml.outputs.info}}" == "11" ] || [[ "${{steps.get-openfire-version-from-plugin-xml.outputs.info}}" =~ ^4\.8.*$ ]]; then
+          if [ "${{steps.get-java-version-from-plugin-xml.outputs.info}}" == "17" ] || [[ "${{steps.get-openfire-version-from-plugin-xml.outputs.info}}" =~ ^4\.10\..*$ ]] || [[ "${{steps.get-openfire-version-from-plugin-xml.outputs.info}}" =~ ^5\..*\..*$ ]]; then
+            echo "java_matrix=[17,21]" >> $GITHUB_OUTPUT
+          elif [ "${{steps.get-java-version-from-plugin-xml.outputs.info}}" == "11" ] || [[ "${{steps.get-openfire-version-from-plugin-xml.outputs.info}}" =~ ^4\.8\..*$ ]] || [[ "${{steps.get-openfire-version-from-plugin-xml.outputs.info}}" =~ ^4\.9\..*$ ]]; then
             echo "java_matrix=[11,17]" >> $GITHUB_OUTPUT
           else
             echo "java_matrix=[8,11,17]" >> $GITHUB_OUTPUT
@@ -120,7 +122,7 @@ jobs:
 
       - name: Stash the built artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.java == 11}}
+        if: ${{ matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') || (matrix.java == '17' && needs.select_java.outputs.java == '[17,21]') }}
         with:
           name: ${{ steps.get-id.outputs.id }}
           path: target/${{ steps.get-id.outputs.id }}-openfire-plugin-assembly.jar
@@ -128,7 +130,7 @@ jobs:
 
       - name: Conditionally Deploy to Igniterealtime Archiva
         id: deploy
-        if: ${{ contains(github.repository, 'igniterealtime/') && ( ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || contains(github.ref, 'refs/tags/')) && ( matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') ) }}
+        if: ${{ contains(github.repository, 'igniterealtime/') && ( ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || contains(github.ref, 'refs/tags/')) && ( matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') || (matrix.java == '17' && needs.select_java.outputs.java == '[17,21]') ) }}
         run: |
           set -e
           mvn -B deploy -Dmaven.resolver.transport=wagon --settings target/ci-tooling/maven-settings-for-openfire-plugins.xml
@@ -138,7 +140,7 @@ jobs:
 
       - name: Conditionally Push Artifact to Github Release
         uses: actions/upload-release-asset@v1
-        if: ${{ contains(github.repository, 'igniterealtime/') && github.event_name == 'push' && contains(github.ref, 'refs/tags/') && ( matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') ) }}
+        if: ${{ contains(github.repository, 'igniterealtime/') && github.event_name == 'push' && contains(github.ref, 'refs/tags/') && ( matrix.java == '8' || (matrix.java == '11' && needs.select_java.outputs.java == '[11,17]') || (matrix.java == '17' && needs.select_java.outputs.java == '[17,21]') ) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Openfire 4.10.* / 5.*.* will require (at least) Java 17. This commit adds that.

The regex used to identify a version number has been slightly modified.

Explicit detection of Openfire 4.9.* has been added